### PR TITLE
Increased reset capacitor latency (NESBoard)

### DIFF
--- a/Breaknes/BreaksCore/CoreApi.h
+++ b/Breaknes/BreaksCore/CoreApi.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#if defined(_WIN32) && !defined(BREAKS_CORE_STATIC)
+#if defined(_WINDOWS) && !defined(BREAKS_CORE_STATIC)
 #define DLL_EXPORT __declspec(dllexport)
 #else
 #define DLL_EXPORT

--- a/Breaknes/BreaksCore/NESBoard.cpp
+++ b/Breaknes/BreaksCore/NESBoard.cpp
@@ -210,7 +210,7 @@ namespace Breaknes
 		// The real board has a capacitor that controls the reset and also the CIC interferes with it, but we simplify all this.
 		// Discussion here: https://forums.nesdev.org/viewtopic.php?t=19792   (nice phenomenon btw)
 
-		resetHalfClkCounter_CPU = 640000;
+		resetHalfClkCounter_CPU = 6400000;
 		resetHalfClkCounter_PPU = 64;
 	}
 


### PR DESCRIPTION
Due to insufficient time to reset PPU (in NES motherboard) - games started using it too early.

I increased the latency of the capacitor on the /RES PPU by a factor of 10.

The FamicomBoard.cpp is not affected by this bug (it does not use /RES on the PPU).